### PR TITLE
✨ [1] Main Page

### DIFF
--- a/src/entities/openings/index.ts
+++ b/src/entities/openings/index.ts
@@ -1,4 +1,6 @@
 import { evansGambit } from './evans-gambit'
 import { staffordGambit } from './stafford-gambit'
 
+export type { Move, FinalMove, PassingMove } from './types'
+
 export const openings = [evansGambit, staffordGambit]

--- a/src/entities/openings/types.ts
+++ b/src/entities/openings/types.ts
@@ -6,16 +6,16 @@ interface MoveBase {
 }
 
 // Имя вариации указывается в её финальном ходе.
-interface FinalMove extends MoveBase {
+export interface FinalMove extends MoveBase {
   name: string
 }
 
 // На каждый ход, кроме финального, есть один или более ответов противника.
-interface PassingMove extends MoveBase {
+export interface PassingMove extends MoveBase {
   replies: Record<SAN, Move>
 }
 
-type Move = FinalMove | PassingMove
+export type Move = FinalMove | PassingMove
 
 // Если это дебют за белых — firstMove будет null.
 // Если за чёрных — в firstMove указан первый ход оппонента.

--- a/src/pages/main/MainPage.vue
+++ b/src/pages/main/MainPage.vue
@@ -1,136 +1,60 @@
 <script setup lang="ts">
-import { useRouter } from 'vue-router'
-import { ref, watch, computed } from 'vue'
+import { useMainPage } from './hook'
 
-import { openings } from '@/entities/openings'
-import type { Opening } from '@/entities/openings/types'
-
-interface Variation {
-  name: string
-}
-
-type Move = Opening['tree']['replies'][string]
-
-const isFinal = (move: Move): move is Move & { name: string } => {
-  return 'name' in move
-}
-
-const findVariations = (tree: Opening['tree']): Variation[] => {
-  const result: Variation[] = []
-
-  const walk = (move: Move) => {
-    if (isFinal(move)) {
-      result.push({ name: move.name })
-
-      return
-    }
-
-    for (const key of Object.keys(move.replies)) {
-      walk(move.replies[key])
-    }
-  }
-
-  for (const key of Object.keys(tree.replies)) {
-    walk(tree.replies[key])
-  }
-
-  return result
-}
-
-const router = useRouter()
-
-const selectedOpeningIndex = ref('')
-const selectedVariation = ref('')
-const selectedMode = ref('')
-
-const selectedOpening = computed(() => {
-  if (selectedOpeningIndex.value === '') return null
-
-  return openings[Number(selectedOpeningIndex.value)] ?? null
-})
-
-const variations = computed(() => {
-  if (!selectedOpening.value) return []
-
-  return findVariations(selectedOpening.value.tree)
-})
-
-const canProceed = computed(() => {
-  return (
-    selectedOpening.value !== null &&
-    selectedVariation.value !== '' &&
-    selectedMode.value !== ''
-  )
-})
-
-watch(selectedOpeningIndex, () => {
-  selectedVariation.value = ''
-})
-
-const go = () => {
-  if (!canProceed.value) return
-
-  router.push(`/${selectedMode.value}`)
-}
+const {
+  linkTo,
+  openingsList,
+  selectedMode,
+  variationsList,
+  selectedOpening,
+  selectedVariation,
+} = useMainPage()
 </script>
 
 <template>
-  <main>
-    <section>
-      <label for="opening-select">Opening</label>
+  <label>
+    Opening
 
-      <select id="opening-select" v-model="selectedOpeningIndex">
-        <option value="" disabled>Select an opening</option>
-
-        <option
-          v-for="(opening, index) in openings"
-          :key="opening.name"
-          :value="String(index)"
-        >
-          {{ opening.name }}
-        </option>
-      </select>
-    </section>
-
-    <section>
-      <label for="variation-select">Variation</label>
-
-      <select
-        id="variation-select"
-        v-model="selectedVariation"
-        :disabled="!selectedOpening"
+    <select v-model="selectedOpening" name="opening-select">
+      <option
+        v-for="opening in openingsList"
+        :key="opening.value"
+        :value="opening.value"
       >
-        <option value="" disabled>Select a variation</option>
+        {{ opening.name }}
+      </option>
+    </select>
+  </label>
 
-        <option
-          v-for="variation in variations"
-          :key="variation.name"
-          :value="variation.name"
-        >
-          {{ variation.name }}
-        </option>
-      </select>
-    </section>
+  <label>
+    Variation
 
-    <section>
-      <label>Mode</label>
+    <select v-model="selectedVariation" name="variation-select">
+      <option
+        v-for="variation in variationsList"
+        :key="variation.value"
+        :value="variation.value"
+      >
+        {{ variation.name }}
+      </option>
+    </select>
+  </label>
 
-      <label>
-        <input v-model="selectedMode" type="radio" name="mode" value="learn" />
-        Learn
-      </label>
+  <fieldset>
+    <legend>Mode</legend>
 
-      <label>
-        <input
-          v-model="selectedMode"
-          type="radio"
-          name="mode"
-          value="practice"
-        />
-        Practice
-      </label>
-    </section>
+    <label>
+      <input v-model="selectedMode" type="radio" name="mode" value="learn" />
 
-    <button :disabled="!canProceed" @click="go">Start</button>
-  </main>
+      Learn
+    </label>
+
+    <label>
+      <input v-model="selectedMode" type="radio" name="mode" value="practice" />
+
+      Practice
+    </label>
+  </fieldset>
+
+  <router-link :to="linkTo">Start</router-link>
 </template>

--- a/src/pages/main/hook.ts
+++ b/src/pages/main/hook.ts
@@ -1,0 +1,50 @@
+import { ref, watch, computed } from 'vue'
+
+import { getVariationsList } from './lib/variations'
+import { getPrefferedMode, setPrefferedMode } from './lib/mode'
+import {
+  getOpeningsList,
+  getPrefferedOpening,
+  setPrefferedOpening,
+} from './lib/openings'
+
+export const useMainPage = () => {
+  const openingsList = getOpeningsList()
+  const selectedMode = ref(getPrefferedMode())
+
+  const selectedOpening = ref(
+    getPrefferedOpening(openingsList.map(({ value }) => value)),
+  )
+
+  const variationsList = computed(() =>
+    getVariationsList(selectedOpening.value, selectedMode.value),
+  )
+
+  const selectedVariation = ref(variationsList.value[0].value)
+
+  const linkTo = computed(() =>
+    [
+      '',
+      selectedMode.value,
+      selectedOpening.value,
+      selectedVariation.value,
+    ].join('/'),
+  )
+
+  watch(selectedMode, setPrefferedMode)
+  watch(selectedOpening, setPrefferedOpening)
+
+  watch(variationsList, variations => {
+    if (!variations.map(({ value }) => value).includes(selectedVariation.value))
+      selectedVariation.value = variations[0].value
+  })
+
+  return {
+    linkTo,
+    openingsList,
+    selectedMode,
+    variationsList,
+    selectedOpening,
+    selectedVariation,
+  }
+}

--- a/src/pages/main/lib/mode.ts
+++ b/src/pages/main/lib/mode.ts
@@ -1,0 +1,18 @@
+import { BoardMode } from '../types'
+
+const MODE_LS_KEY = 'preffered-mode'
+
+export const getPrefferedMode = (): BoardMode => {
+  const fromLs = localStorage.getItem(MODE_LS_KEY)
+
+  if (fromLs === 'practice') {
+    return fromLs
+  }
+
+  localStorage.setItem(MODE_LS_KEY, 'learn')
+
+  return 'learn'
+}
+
+export const setPrefferedMode = (mode: BoardMode) =>
+  localStorage.setItem(MODE_LS_KEY, mode)

--- a/src/pages/main/lib/openings.ts
+++ b/src/pages/main/lib/openings.ts
@@ -1,0 +1,29 @@
+import { kebabize } from '@/shared'
+import { openings } from '@/entities/openings'
+
+import { SelectorItem } from '../types'
+
+const OPENING_LS_KEY = 'preffered-opening'
+
+export const getOpeningsList = () =>
+  openings.map<SelectorItem>(opening => ({
+    name: opening.name,
+    value: kebabize(opening.name),
+  }))
+
+export const getPrefferedOpening = (availableValues: string[]) => {
+  const fromLs = localStorage.getItem(OPENING_LS_KEY)
+
+  if (!fromLs || !availableValues.includes(fromLs)) {
+    const newValue = availableValues[0]
+
+    localStorage.setItem(OPENING_LS_KEY, newValue)
+
+    return newValue
+  }
+
+  return fromLs
+}
+
+export const setPrefferedOpening = (value: string) =>
+  localStorage.setItem(OPENING_LS_KEY, value)

--- a/src/pages/main/lib/variations.ts
+++ b/src/pages/main/lib/variations.ts
@@ -1,0 +1,53 @@
+import { kebabize } from '@/shared'
+import { Move, openings, FinalMove, PassingMove } from '@/entities/openings'
+
+import { BoardMode, SelectorItem } from '../types'
+
+const isFinal = (move: Move): move is FinalMove => 'name' in move
+
+const findVariations = (root: PassingMove): SelectorItem[] => {
+  const result: SelectorItem[] = []
+
+  const walk = (move: Move) => {
+    if (isFinal(move)) {
+      result.push({
+        name: move.name,
+        value: kebabize(move.name),
+      })
+
+      return
+    }
+
+    for (const key of Object.keys(move.replies)) {
+      walk(move.replies[key])
+    }
+  }
+
+  for (const key of Object.keys(root.replies)) {
+    walk(root.replies[key])
+  }
+
+  return result
+}
+
+export const getVariationsList = (
+  openingValue: string,
+  mode: BoardMode,
+): SelectorItem[] => {
+  const opening = openings.find(({ name }) => kebabize(name) === openingValue)
+
+  if (!opening) throw new Error(`No opening found by value ${openingValue}`)
+
+  return [
+    mode === 'learn'
+      ? {
+          name: 'Initial Line',
+          value: 'initial-line',
+        }
+      : {
+          name: 'All Lines',
+          value: 'all-lines',
+        },
+    ...findVariations(opening.tree),
+  ]
+}

--- a/src/pages/main/types.ts
+++ b/src/pages/main/types.ts
@@ -1,0 +1,6 @@
+export type BoardMode = 'learn' | 'practice'
+
+export interface SelectorItem {
+  name: string
+  value: string
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,0 +1,1 @@
+export * from './strings'

--- a/src/shared/strings.ts
+++ b/src/shared/strings.ts
@@ -1,0 +1,2 @@
+export const kebabize = (source: string) =>
+  source.toLowerCase().split(' ').join('-')


### PR DESCRIPTION
**Время:** ~30 мин
**Ресурсы:** субагент (claude-opus)

**Суть решения:**
Реализована главная страница с выбором дебюта, вариации и режима.
- Выбор дебюта из массива `openings`
- Рекурсивный обход дерева для поиска всех вариаций (`FinalMove` с полем `name`)
- Выбор режима: learn / practice
- Кнопка Start: `disabled` до полного выбора, при клике — `router.push`
- При смене дебюта вариация сбрасывается

**Не предвидели:**
git push по HTTPS не работал через токен — ветку запушил Нелкор вручную через SSH. PR-доступ также потребовал перенастройки токена.

**Новые либы:** нет