### PR TITLE
✨ [4] Board Transition

### DIFF
--- a/src/app/router.ts
+++ b/src/app/router.ts
@@ -3,6 +3,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import { MainPage } from '@/pages/main'
 import { LearnPage } from '@/pages/learn'
 import { PracticePage } from '@/pages/practice'
+import { resolveRoute } from '@/entities/openings'
 
 export const router = createRouter({
   history: createWebHistory(),
@@ -14,13 +15,37 @@ export const router = createRouter({
     },
     {
       name: 'learn',
-      path: '/learn',
       component: LearnPage,
+      path: '/learn/:opening/:variation',
+      beforeEnter: to => {
+        const { opening, variation } = to.params
+        const resolved = resolveRoute(
+          opening as string,
+          variation as string,
+          'learn',
+        )
+
+        if (!resolved) {
+          return { name: 'root' }
+        }
+      },
     },
     {
       name: 'practice',
-      path: '/practice',
       component: PracticePage,
+      path: '/practice/:opening/:variation',
+      beforeEnter: to => {
+        const { opening, variation } = to.params
+        const resolved = resolveRoute(
+          opening as string,
+          variation as string,
+          'practice',
+        )
+
+        if (!resolved) {
+          return { name: 'root' }
+        }
+      },
     },
 
     // unfamiliar path

--- a/src/entities/openings/data.ts
+++ b/src/entities/openings/data.ts
@@ -1,0 +1,4 @@
+import { evansGambit } from './evans-gambit'
+import { staffordGambit } from './stafford-gambit'
+
+export const openings = [evansGambit, staffordGambit]

--- a/src/entities/openings/index.ts
+++ b/src/entities/openings/index.ts
@@ -1,6 +1,5 @@
-import { evansGambit } from './evans-gambit'
-import { staffordGambit } from './stafford-gambit'
+export { openings } from './data'
+export { resolveRoute } from './resolve'
 
+export type { ResolvedRoute } from './resolve'
 export type { Move, FinalMove, PassingMove } from './types'
-
-export const openings = [evansGambit, staffordGambit]

--- a/src/entities/openings/resolve.ts
+++ b/src/entities/openings/resolve.ts
@@ -1,0 +1,69 @@
+import { kebabize } from '@/shared'
+
+import { openings } from './data'
+import { Move, FinalMove, PassingMove } from './types'
+
+const isFinal = (move: Move): move is FinalMove => 'name' in move
+
+const collectVariationNames = (root: PassingMove): string[] => {
+  const result: string[] = []
+
+  const walk = (move: Move) => {
+    if (isFinal(move)) {
+      result.push(move.name)
+
+      return
+    }
+
+    for (const key of Object.keys(move.replies)) {
+      walk(move.replies[key])
+    }
+  }
+
+  for (const key of Object.keys(root.replies)) {
+    walk(root.replies[key])
+  }
+
+  return result
+}
+
+export interface ResolvedRoute {
+  openingName: string
+  variationName: string
+}
+
+export const resolveRoute = (
+  openingValue: string,
+  variationValue: string,
+  mode: string,
+): ResolvedRoute | null => {
+  const opening = openings.find(({ name }) => kebabize(name) === openingValue)
+
+  if (!opening) {
+    return null
+  }
+
+  const specialValue = mode === 'learn' ? 'initial-line' : 'all-lines'
+  const specialName = mode === 'learn' ? 'Initial Line' : 'All Lines'
+
+  if (variationValue === specialValue) {
+    return {
+      openingName: opening.name,
+      variationName: specialName,
+    }
+  }
+
+  const variationNames = collectVariationNames(opening.tree)
+  const variationName = variationNames.find(
+    name => kebabize(name) === variationValue,
+  )
+
+  if (!variationName) {
+    return null
+  }
+
+  return {
+    variationName,
+    openingName: opening.name,
+  }
+}

--- a/src/pages/learn/LearnPage.vue
+++ b/src/pages/learn/LearnPage.vue
@@ -1,7 +1,16 @@
 <script setup lang="ts">
 import { TheChessboard } from 'vue3-chessboard'
+
+import { useLearnPage } from './hook'
+
+const { openingName, variationName } = useLearnPage()
 </script>
 
 <template>
+  <h1>{{ openingName }}</h1>
+  <h2>{{ variationName }}</h2>
+
   <TheChessboard />
+
+  <router-link to="/">Back to main</router-link>
 </template>

--- a/src/pages/learn/hook.ts
+++ b/src/pages/learn/hook.ts
@@ -1,0 +1,13 @@
+import { useRoute } from 'vue-router'
+
+import { resolveRoute, ResolvedRoute } from '@/entities/openings'
+
+export const useLearnPage = (): ResolvedRoute => {
+  const route = useRoute()
+
+  const { opening, variation } = route.params
+
+  const resolved = resolveRoute(opening as string, variation as string, 'learn')
+
+  return resolved as ResolvedRoute
+}

--- a/src/pages/practice/PracticePage.vue
+++ b/src/pages/practice/PracticePage.vue
@@ -1,7 +1,16 @@
 <script setup lang="ts">
 import { TheChessboard } from 'vue3-chessboard'
+
+import { usePracticePage } from './hook'
+
+const { openingName, variationName } = usePracticePage()
 </script>
 
 <template>
+  <h1>{{ openingName }}</h1>
+  <h2>{{ variationName }}</h2>
+
   <TheChessboard />
+
+  <router-link to="/">Back to main</router-link>
 </template>

--- a/src/pages/practice/hook.ts
+++ b/src/pages/practice/hook.ts
@@ -1,0 +1,17 @@
+import { useRoute } from 'vue-router'
+
+import { resolveRoute, ResolvedRoute } from '@/entities/openings'
+
+export const usePracticePage = (): ResolvedRoute => {
+  const route = useRoute()
+
+  const { opening, variation } = route.params
+
+  const resolved = resolveRoute(
+    opening as string,
+    variation as string,
+    'practice',
+  )
+
+  return resolved as ResolvedRoute
+}


### PR DESCRIPTION
**Сколько времени заняло:** ~5 минут.

**Какие ресурсы использованы:** Claude Opus (1 субагент-сессия).

**Что не предвидел при старте:** Необходимость разделить `entities/openings/index.ts` на `data.ts` и `resolve.ts`, чтобы избежать циклических зависимостей — функция `resolveRoute` импортирует данные дебютов, а `index.ts` ре-экспортирует и то, и другое.

**Новые либы:** Нет.

**Суть решения:**

1. **Роутер** — маршруты `/learn` и `/practice` заменены на `/learn/:opening/:variation` и `/practice/:opening/:variation`. Каждый маршрут имеет `beforeEnter`-гард, который через `resolveRoute()` проверяет валидность дебюта и вариации. При невалидных параметрах — редирект на главную. Catch-all маршрут сохранён.

2. **entities/openings** — добавлен `resolve.ts` с функцией `resolveRoute(openingValue, variationValue, mode)`, которая по kebab-значениям ищет дебют и вариацию, возвращая `{ openingName, variationName }` или `null`. Учитывает специальные вариации: `initial-line` (learn) и `all-lines` (practice). Данные вынесены в отдельный `data.ts`.

3. **Страницы доски** — `LearnPage` и `PracticePage` получили хуки, которые читают параметры маршрута и резолвят имена. Компоненты отображают название дебюта (`<h1>`), название вариации (`<h2>`), шахматную доску и ссылку «Back to main» на главную.